### PR TITLE
Implement list_work_items handler with tests

### DIFF
--- a/project-management/task-management/doing.md
+++ b/project-management/task-management/doing.md
@@ -1,15 +1,1 @@
 ## Current Tasks In Progress
-
-- [ ] **Task 2.4**: Implement `update_work_item` handler with tests
-  - **Role**: Full-Stack Developer
-  - **Phase**: Implementation
-  - **Description**: Implement the `update_work_item` handler for the Azure DevOps MCP server with comprehensive tests.
-  - **Notes**: 
-    - Will explore the Azure DevOps API for updating work items
-    - Will follow TDD approach (red-green-refactor)
-    - Will ensure proper error handling and validation
-  - **Sub-tasks**:
-    - [x] Research Azure DevOps API for updating work items
-    - [x] Write failing tests for the update_work_item handler
-    - [x] Implement the handler to make tests pass
-    - [x] Refactor and optimize the implementation

--- a/project-management/task-management/done.md
+++ b/project-management/task-management/done.md
@@ -1,4 +1,16 @@
 ## Completed Tasks
+- [x] **Task 2.6**: Implement `list_work_items` handler with tests
+  - **Role**: Full-Stack Developer
+  - **Phase**: Completion
+  - **Description**: Implement the `list_work_items` tool for the Azure DevOps MCP server using WebApi with tests.
+  - **Notes**:
+    - Implemented the `list_work_items` handler according to the pattern established in server-coverage.test.ts
+    - Created comprehensive unit tests for the handler function
+    - Fixed the test file to properly mock Azure DevOps API
+    - Ensured all tests pass successfully
+    - Implemented error handling for API errors and validation errors
+    - Aligned the implementation with the established project patterns
+
 - [x] **Task 1.8**: Document core navigation tools (usage, parameters)
   - **Role**: Technical Writer
   - **Phase**: Completion
@@ -302,6 +314,24 @@
     - Created detailed documentation in docs/tools/work-items.md
     - Updated the main documentation index to include work item tools
   - **Completed**: March 15, 2024
+
+- [x] **Task 2.4**: Implement `update_work_item` handler with tests
+  - **Role**: Full-Stack Developer
+  - **Phase**: Completion
+  - **Description**: Implement the `update_work_item` handler for the Azure DevOps MCP server with comprehensive tests.
+  - **Notes**:
+    - Implemented the `update_work_item` handler for updating existing work items in Azure DevOps
+    - Created comprehensive unit tests with high coverage
+    - Ensured proper error handling and validation
+    - Added support for updating various fields including title, description, state, and custom fields
+    - Integrated the handler with the MCP server interface
+  - **Sub-tasks**:
+    - [x] Research Azure DevOps API for updating work items
+    - [x] Write failing tests for the update_work_item handler
+    - [x] Implement the handler to make tests pass
+    - [x] Refactor and optimize the implementation
+  - **Completed**: March 20, 2024
+  - **Pull Request**: [#18](https://github.com/Tiberriver256/azure-devops-mcp/pull/18)
 
 ### Task 0.1: Initialize Git repository and set up branch policies
 **Role**: Full-Stack Developer

--- a/project-management/task-management/todo.md
+++ b/project-management/task-management/todo.md
@@ -8,8 +8,6 @@
 
 ### Authentication Enhancements
 
-- [ ] **Task 2.6**: Implement `list_work_items` handler with tests
-  - **Role**: Full-Stack Developer
 - [ ] **Task 2.8**: Implement `get_work_item` handler with tests
   - **Role**: Full-Stack Developer
 - [ ] **Task 2.10**: Implement `add_work_item_comment` handler with tests

--- a/tests/unit/operations/workitems/list-work-items.test.ts
+++ b/tests/unit/operations/workitems/list-work-items.test.ts
@@ -1,0 +1,273 @@
+import { WebApi } from 'azure-devops-node-api';
+import { getPersonalAccessTokenHandler } from 'azure-devops-node-api';
+import { 
+  WorkItem, 
+  WorkItemQueryResult,
+  WorkItemExpand
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import { listWorkItems } from '../../../../src/operations/workitems';
+import { AzureDevOpsResourceNotFoundError } from '../../../../src/common/errors';
+
+// Mock the Azure DevOps WebApi and handler
+jest.mock('azure-devops-node-api');
+
+describe('List Work Items Operation', () => {
+  let mockConnection: jest.Mocked<WebApi>;
+  let mockWitApi: any;
+
+  beforeEach(() => {
+    // Create mock objects
+    mockWitApi = {
+      queryByWiql: jest.fn(),
+      queryById: jest.fn(),
+      getWorkItems: jest.fn(),
+    };
+
+    // Create a mock handler and WebApi
+    const mockHandler = getPersonalAccessTokenHandler('fake-token');
+    mockConnection = new WebApi('https://dev.azure.com/organization', mockHandler) as jest.Mocked<WebApi>;
+    mockConnection.getWorkItemTrackingApi = jest.fn().mockResolvedValue(mockWitApi);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const mockWorkItems: WorkItem[] = [
+    {
+      id: 123,
+      url: 'https://dev.azure.com/org/project/_apis/wit/workItems/123',
+      fields: {
+        'System.Id': 123,
+        'System.Title': 'Work Item 1',
+        'System.State': 'Active',
+      },
+    },
+    {
+      id: 124,
+      url: 'https://dev.azure.com/org/project/_apis/wit/workItems/124',
+      fields: {
+        'System.Id': 124,
+        'System.Title': 'Work Item 2',
+        'System.State': 'Resolved',
+      },
+    },
+  ];
+
+  const mockQueryResult: WorkItemQueryResult = {
+    workItems: [
+      { id: 123, url: 'https://dev.azure.com/org/project/_apis/wit/workItems/123' },
+      { id: 124, url: 'https://dev.azure.com/org/project/_apis/wit/workItems/124' },
+    ],
+  };
+
+  describe('with WIQL query', () => {
+    it('should return work items using WIQL query', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+      };
+      mockWitApi.queryByWiql.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce(mockWorkItems);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalledTimes(1);
+      expect(mockWitApi.queryByWiql).toHaveBeenCalledWith(
+        { query: options.wiql },
+        {
+          project: options.projectId,
+          team: undefined,
+        },
+      );
+      expect(mockWitApi.getWorkItems).toHaveBeenCalledWith(
+        [123, 124],
+        ["System.Id", "System.Title", "System.State", "System.AssignedTo"],
+        undefined,
+        WorkItemExpand.All,
+      );
+      expect(result).toEqual(mockWorkItems);
+    });
+
+    it('should use default WIQL when no query or queryId is provided', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+      };
+      mockWitApi.queryByWiql.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce(mockWorkItems);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalledTimes(1);
+      expect(mockWitApi.queryByWiql).toHaveBeenCalledWith(
+        { query: expect.stringContaining('SELECT [System.Id] FROM WorkItems') },
+        {
+          project: options.projectId,
+          team: undefined,
+        },
+      );
+      expect(mockWitApi.getWorkItems).toHaveBeenCalled();
+      expect(result).toEqual(mockWorkItems);
+    });
+
+    it('should include team context when teamId is provided', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+        teamId: 'team-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+      };
+      mockWitApi.queryByWiql.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce(mockWorkItems);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalledTimes(1);
+      expect(mockWitApi.queryByWiql).toHaveBeenCalledWith(
+        { query: options.wiql },
+        {
+          project: options.projectId,
+          team: options.teamId,
+        },
+      );
+      expect(result).toEqual(mockWorkItems);
+    });
+  });
+
+  describe('with Query ID', () => {
+    it('should return work items using queryId', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+        queryId: 'query-id',
+      };
+      mockWitApi.queryById.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce(mockWorkItems);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalledTimes(1);
+      expect(mockWitApi.queryById).toHaveBeenCalledWith(
+        options.queryId,
+        {
+          project: options.projectId,
+          team: undefined,
+        },
+      );
+      expect(mockWitApi.getWorkItems).toHaveBeenCalled();
+      expect(result).toEqual(mockWorkItems);
+    });
+  });
+
+  describe('pagination', () => {
+    it('should handle top parameter', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+        top: 1,
+      };
+      mockWitApi.queryByWiql.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce([mockWorkItems[0]]);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockWitApi.queryByWiql).toHaveBeenCalled();
+      expect(mockWitApi.getWorkItems).toHaveBeenCalledWith(
+        [123], // Only the first ID should be used due to top: 1
+        ["System.Id", "System.Title", "System.State", "System.AssignedTo"],
+        undefined,
+        WorkItemExpand.All,
+      );
+      expect(result).toEqual([mockWorkItems[0]]);
+    });
+
+    it('should handle skip parameter', async () => {
+      // Arrange
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+        skip: 1,
+      };
+      mockWitApi.queryByWiql.mockResolvedValueOnce(mockQueryResult);
+      mockWitApi.getWorkItems.mockResolvedValueOnce([mockWorkItems[1]]);
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockWitApi.queryByWiql).toHaveBeenCalled();
+      expect(mockWitApi.getWorkItems).toHaveBeenCalledWith(
+        [124], // Only the second ID should be used due to skip: 1
+        ["System.Id", "System.Title", "System.State", "System.AssignedTo"],
+        undefined,
+        WorkItemExpand.All,
+      );
+      expect(result).toEqual([mockWorkItems[1]]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle empty query results', async () => {
+      // Arrange
+      mockWitApi.queryByWiql.mockResolvedValue({ workItems: [] });
+      
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+      };
+
+      // Act
+      const result = await listWorkItems(mockConnection, options);
+
+      // Assert
+      expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalledTimes(1);
+      expect(mockWitApi.queryByWiql).toHaveBeenCalled();
+      expect(mockWitApi.getWorkItems).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('should wrap errors', async () => {
+      // Arrange
+      mockWitApi.queryByWiql.mockRejectedValue(new Error('API error'));
+      
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+      };
+
+      // Act & Assert
+      await expect(listWorkItems(mockConnection, options)).rejects.toThrow(
+        'Failed to list work items: API error'
+      );
+    });
+
+    it('should propagate AzureDevOpsResourceNotFoundError', async () => {
+      // Arrange
+      const error = new AzureDevOpsResourceNotFoundError('Project not found');
+      mockWitApi.queryByWiql.mockRejectedValue(error);
+      
+      const options = {
+        projectId: 'project-id',
+        wiql: 'SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project',
+      };
+
+      // Act & Assert
+      await expect(listWorkItems(mockConnection, options)).rejects.toThrow(
+        AzureDevOpsResourceNotFoundError
+      );
+    });
+  });
+}); 

--- a/tests/unit/server-list-work-items.test.ts
+++ b/tests/unit/server-list-work-items.test.ts
@@ -1,0 +1,193 @@
+// Mock modules need to be defined before imports
+const mockWebApiConstructor = jest.fn().mockImplementation(() => {
+  return {
+    getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+      queryById: jest.fn().mockResolvedValue({
+        workItems: []
+      }),
+      queryByWiql: jest.fn().mockResolvedValue({
+        workItems: []
+      }),
+      getWorkItems: jest.fn().mockResolvedValue([])
+    }),
+    getLocationsApi: jest.fn().mockResolvedValue({
+      getResourceAreas: jest.fn().mockResolvedValue([])
+    }),
+    getCoreApi: jest.fn().mockResolvedValue({
+      getProjects: jest.fn().mockResolvedValue([]),
+      getProject: jest.fn().mockResolvedValue({})
+    }),
+    getGitApi: jest.fn().mockResolvedValue({})
+  };
+});
+
+const mockGetPersonalAccessTokenHandler = jest.fn();
+const mockGetBearerHandler = jest.fn();
+
+jest.mock('azure-devops-node-api', () => ({
+  WebApi: mockWebApiConstructor,
+  getPersonalAccessTokenHandler: mockGetPersonalAccessTokenHandler,
+  getBearerHandler: mockGetBearerHandler
+}));
+
+// Mock the server module to avoid authentication errors
+jest.mock('../../src/server', () => {
+  const originalModule = jest.requireActual('../../src/server');
+  
+  return {
+    ...originalModule,
+    testConnection: jest.fn().mockResolvedValue(true)
+  };
+});
+
+// Define mock server class
+class MockServerClass {
+  setRequestHandler = jest.fn();
+  registerTool = jest.fn();
+  capabilities = {
+    tools: {} as Record<string, { name: string }>
+  };
+}
+
+// Mock the MCP SDK modules
+jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: jest.fn().mockImplementation(() => new MockServerClass())
+}));
+
+jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ListToolsRequestSchema: 'ListToolsRequestSchema',
+  CallToolRequestSchema: 'CallToolRequestSchema'
+}));
+
+// Now import modules
+import { z } from 'zod';
+import { AzureDevOpsError } from '../../src/common/errors';
+import { AuthenticationMethod } from '../../src/auth';
+
+// Define schema objects
+const ListWorkItemsSchema = z.object({
+  projectId: z.string(),
+  teamId: z.string().optional(),
+  queryId: z.string().optional(),
+  wiql: z.string().optional(),
+  top: z.number().optional(),
+  skip: z.number().optional(),
+});
+
+// Mock the workitems module
+jest.mock('../../src/operations/workitems', () => ({
+  ListWorkItemsSchema,
+  listWorkItems: jest.fn(),
+}));
+
+// Import the mocked modules
+import { listWorkItems } from '../../src/operations/workitems';
+import { createAzureDevOpsServer } from '../../src/server';
+
+describe('Server - list_work_items Tool', () => {
+  let mockServer: MockServerClass;
+  let callToolHandler: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Initialize the mock server
+    mockServer = new MockServerClass();
+    
+    // Mock the Server constructor to return our mockServer
+    (require('@modelcontextprotocol/sdk/server/index.js').Server as jest.Mock).mockReturnValue(mockServer);
+    
+    // Create server instance with minimal config
+    createAzureDevOpsServer({
+      authMethod: AuthenticationMethod.PersonalAccessToken,
+      personalAccessToken: 'fake-pat',
+      organizationUrl: 'https://dev.azure.com/fake-org',
+    });
+    
+    // Get the CallToolRequestSchema handler
+    callToolHandler = mockServer.setRequestHandler.mock.calls.find(
+      (call: any[]) => call[0] === 'CallToolRequestSchema'
+    )?.[1];
+  });
+
+  it('should handle list_work_items tool call', async () => {
+    // Mock the listWorkItems function to return some work items
+    const mockWorkItems = [
+      { id: 123, fields: { 'System.Title': 'Work Item 1' } },
+      { id: 456, fields: { 'System.Title': 'Work Item 2' } },
+    ];
+    (listWorkItems as jest.Mock).mockResolvedValueOnce(mockWorkItems);
+    
+    // Call the handler with list_work_items tool
+    const result = await callToolHandler({
+      params: {
+        name: 'list_work_items',
+        arguments: {
+          projectId: 'project1',
+          wiql: 'SELECT [System.Id] FROM WorkItems',
+        },
+      },
+    });
+    
+    // Verify the result
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(mockWorkItems, null, 2),
+        },
+      ],
+    });
+    
+    // Verify the listWorkItems function was called with correct parameters
+    expect(listWorkItems).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        projectId: 'project1',
+        wiql: 'SELECT [System.Id] FROM WorkItems',
+      }
+    );
+  });
+
+  it('should handle validation errors', async () => {
+    // Mock listWorkItems to throw a validation error
+    (listWorkItems as jest.Mock).mockImplementation(() => {
+      // This won't be called because the zod validation will fail
+      return Promise.resolve([]);
+    });
+    
+    // Call the handler with invalid arguments (missing required projectId)
+    const result = await callToolHandler({
+      params: {
+        name: 'list_work_items',
+        arguments: {
+          // Missing projectId
+          wiql: 'SELECT [System.Id] FROM WorkItems',
+        },
+      },
+    });
+    
+    // Verify the result contains an error message
+    expect(result.content[0].text).toContain('Required');
+  });
+
+  it('should handle API errors', async () => {
+    // Mock the listWorkItems function to throw an error
+    (listWorkItems as jest.Mock).mockRejectedValueOnce(
+      new AzureDevOpsError('API error')
+    );
+    
+    // Call the handler
+    const result = await callToolHandler({
+      params: {
+        name: 'list_work_items',
+        arguments: {
+          projectId: 'project1',
+        },
+      },
+    });
+    
+    // Verify the result contains an error message
+    expect(result.content[0].text).toContain('API error');
+  });
+}); 


### PR DESCRIPTION
This pull request includes several updates related to task management and unit tests for the Azure DevOps MCP server. The most important changes include the completion and documentation of specific tasks, the removal of tasks from the to-do list, and the addition of unit tests for the `list_work_items` handler.

Task Management Updates:

* [`project-management/task-management/doing.md`](diffhunk://#diff-28f5504d524a3a8d9ce89517168b8a561add549e41b5254b5dd5073c9af83e45L2-L15): Removed Task 2.4, which involved implementing the `update_work_item` handler with tests.
* [`project-management/task-management/done.md`](diffhunk://#diff-7484241519f66fa4247380bd305cbaebabf20bcbe3511f8ee56482c0947bbf0bR2-R13): Added Task 2.6 and Task 2.4 to the list of completed tasks, documenting the implementation and testing of the `list_work_items` and `update_work_item` handlers, respectively. [[1]](diffhunk://#diff-7484241519f66fa4247380bd305cbaebabf20bcbe3511f8ee56482c0947bbf0bR2-R13) [[2]](diffhunk://#diff-7484241519f66fa4247380bd305cbaebabf20bcbe3511f8ee56482c0947bbf0bR318-R335)
* [`project-management/task-management/todo.md`](diffhunk://#diff-75a2485d91058e0d57fb742b4806520514bc2014746e2d2de85a42bceefbe224L11-L12): Removed Task 2.6 from the to-do list, which involved implementing the `list_work_items` handler with tests.

Unit Tests:

* [`tests/unit/operations/workitems/list-work-items.test.ts`](diffhunk://#diff-fe5fce3fd22d72983a28cd99c07209eee8c0237cd5cfa859bc7165ce6f62b083R1-R273): Added comprehensive unit tests for the `listWorkItems` function, including tests for WIQL queries, query IDs, pagination, and error handling.
* [`tests/unit/server-list-work-items.test.ts`](diffhunk://#diff-4a6e1da5890dcf69f36f83db0636fe5ce616cedd583c648074ca15a2a08d804bR1-R193): Added unit tests for the server-side handling of the `list_work_items` tool, including validation and API error handling.