### PR TITLE
fix: add tag_name parameter to GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: v${{ steps.package-version.outputs.version }}
           generate_release_notes: true 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds the `tag_name` parameter to the `jobs:` section, using the version output from the `package-version` step.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R58): Added `tag_name: v${{ steps.package-version.outputs.version }}` to the `jobs:` section to specify the tag name for the release.