### PR TITLE
Add npm publish to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
         run: git push --follow-tags origin main
         # Ensure this pushes to the correct branch (e.g., main)
 
+      - name: Publish to npm
+        run: npm publish --access public # <-- Scoped packages need --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         env:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow for releasing the project. The change adds a step to publish the package to npm.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R53-R57): Added a step to publish the package to npm with the necessary environment variable for authentication.